### PR TITLE
Incorrect handling of non-ascii characters

### DIFF
--- a/qsstv/dispatch/dispatcher.cpp
+++ b/qsstv/dispatch/dispatcher.cpp
@@ -279,7 +279,7 @@ void dispatcher::customEvent( QEvent * e )
       break;
 //    case notifyAction: // sends notification after reception of hybrid image
 //      // todo     notifyRXIntfPtr->mremove(((notifyActionEvent*)e)->getToRemove());
-//      //      notifyRXIntfPtr->uploadData(((notifyActionEvent*)e)->getMsg().toLatin1(), ((notifyActionEvent*)e)->getFilename());
+//      //      notifyRXIntfPtr->uploadData(((notifyActionEvent*)e)->getMsg().toUtf8(), ((notifyActionEvent*)e)->getFilename());
 //      break;
 
     case notifyCheck:
@@ -513,7 +513,7 @@ void dispatcher::saveImage(QString fileName, QString infotext)
       p.setBrush(Qt::white);
       p.setFont(font);
       p.drawText(2,height-fontm.descent()-1, text);
-      im.save( fn, ftpDefaultImageFormat.toUpper().toLatin1().data());
+      im.save( fn, ftpDefaultImageFormat.toUpper().toUtf8().data());
       p.end();
       uploadToRXServer(remoteDir, fn);
     }

--- a/qsstv/drmrx/sourcedecoder.cpp
+++ b/qsstv/drmrx/sourcedecoder.cpp
@@ -392,7 +392,7 @@ void sourceDecoder::loadParams(transportBlock *tbPtr,unsigned char paramID,int l
     case 6:
       break;
     case 12:
-      tbPtr->fileName=QString::fromLatin1(currentDataPacket.ba.data()+1).left(len-1);
+      tbPtr->fileName=QString::fromUtf8(currentDataPacket.ba.data()+1).left(len-1);
       stce= new rxDRMStatusEvent(QString("%1").arg(tbPtr->fileName));
       QApplication::postEvent( dispatcherPtr, stce );  // Qt will delete it when done
       break;
@@ -542,7 +542,7 @@ void sourceDecoder::saveImage(transportBlock *tbPtr)
                 {
                   ff->setupFtp("GetHybridImage",hc.host(),hc.port(),hc.user(),hc.passwd(),hc.dir()+"/"+hybridFtpHybridFilesDirectory);
 
-                  ff->downloadFile(tbPtr->fileName.toLatin1(),downloadF,false,false);
+                  ff->downloadFile(tbPtr->fileName.toUtf8(),downloadF,false,false);
                 }
               tbPtr->retrieveTries++;
 
@@ -743,12 +743,12 @@ bool sourceDecoder::storeBSR(transportBlock *tb, bool compat)
     }
   tb->baBSR.clear();
   if(erasureList.count()<3) return false; //erasurelist has already totalSegments and defaultSegmentSize
-  tb->baBSR.append(QString::number(tb->transportID).toLatin1().data());
+  tb->baBSR.append(QString::number(tb->transportID).toUtf8().data());
   tb->baBSR.append("\n");
   tb->baBSR.append("H_OK\n");
-  tb->baBSR.append(QString::number(erasureList.at(1)).toLatin1().data());
+  tb->baBSR.append(QString::number(erasureList.at(1)).toUtf8().data());
   tb->baBSR.append("\n");
-  tb->baBSR.append(QString::number(erasureList.at(2)).toLatin1().data());
+  tb->baBSR.append(QString::number(erasureList.at(2)).toUtf8().data());
   tb->baBSR.append("\n");
 
   prevErasure=erasureList.at(2);
@@ -763,21 +763,21 @@ bool sourceDecoder::storeBSR(transportBlock *tb, bool compat)
         {
           if(needsFiller)
             {
-              tb->baBSR.append(QString::number(-1).toLatin1().data());
+              tb->baBSR.append(QString::number(-1).toUtf8().data());
               tb->baBSR.append("\n");
               needsFiller=false;
             }
-          tb->baBSR.append(QString::number(erasureList.at(i)).toLatin1().data());
+          tb->baBSR.append(QString::number(erasureList.at(i)).toUtf8().data());
           tb->baBSR.append("\n");
         }
       prevErasure=erasureList.at(i);
     }
   if(needsFiller)
     {
-      tb->baBSR.append(QString::number(-1).toLatin1().data());
+      tb->baBSR.append(QString::number(-1).toUtf8().data());
       tb->baBSR.append("\n");
       needsFiller=false;
-      tb->baBSR.append(QString::number(erasureList.at(erasureList.count()-1)).toLatin1().data());
+      tb->baBSR.append(QString::number(erasureList.at(erasureList.count()-1)).toUtf8().data());
       tb->baBSR.append("\n");
     }
   tb->baBSR.append("-99\n");

--- a/qsstv/drmtx/common/datadecoding/MOTSlideShow.cpp
+++ b/qsstv/drmtx/common/datadecoding/MOTSlideShow.cpp
@@ -98,11 +98,11 @@ void CMOTSlideShowEncoder::AddNextPicture ()
     {
       /* Get current file name */
       QString tmp=vecPicFileNames[iPictureCnt].name+"."+vecPicFileNames[iPictureCnt].format;
-      strCurObjName = tmp.toLatin1().data();
+      strCurObjName = tmp.toUtf8().data();
       CMOTObject MOTPicture;
           /* Set file name and format string */
       MOTPicture.strName = strCurObjName;
-      MOTPicture.strFormat = vecPicFileNames[iPictureCnt].format.toLatin1().data();
+      MOTPicture.strFormat = vecPicFileNames[iPictureCnt].format.toUtf8().data();
       MOTPicture.vecbRawData.Init (0);
       for(i=0;i<vecPicFileNames[iPictureCnt].arrayPtr->count();i++)
          {
@@ -127,6 +127,6 @@ void CMOTSlideShowEncoder::AddArray (QByteArray *ba,const QString name,const QSt
     int iOldNumObj = vecPicFileNames.Size ();
     vecPicFileNames.Enlarge (1);
     vecPicFileNames[iOldNumObj].arrayPtr = ba;
-    vecPicFileNames[iOldNumObj].name=name.toLatin1();
+    vecPicFileNames[iOldNumObj].name=name.toUtf8();
     vecPicFileNames[iOldNumObj].format=format;
 }

--- a/qsstv/drmtx/drmtransmitter.cpp
+++ b/qsstv/drmtx/drmtransmitter.cpp
@@ -109,7 +109,7 @@ void drmTransmitter::init(QByteArray *ba, QString name, QString format, drmTxPar
   Service.iServiceDescr=0;
   Service.iServiceID=0;
   Service.iLanguage=5;
-  Service.strLabel=params.callsign.toLatin1().data();
+  Service.strLabel=params.callsign.toUtf8().data();
   TransmParam->SetServiceParameters(0,Service);
   DRMTransmitter->Init();
   // calculate transmision time

--- a/qsstv/rig/rigcontrol.cpp
+++ b/qsstv/rig/rigcontrol.cpp
@@ -82,14 +82,14 @@ bool rigControl::init()
     {
       if(!catParams.civAddress.isEmpty())
         {
-          rig_set_conf(my_rig, rig_token_lookup(my_rig, "civaddr"), catParams.civAddress.toLatin1());
+          rig_set_conf(my_rig, rig_token_lookup(my_rig, "civaddr"), catParams.civAddress.toUtf8());
         }
     }
   if(!catParams.serialPort.isEmpty())
      {
-      strncpy(my_rig->state.rigport.pathname,(const char *)catParams.serialPort.toLatin1().data(),FILPATHLEN);
+      strncpy(my_rig->state.rigport.pathname,(const char *)catParams.serialPort.toUtf8().data(),FILPATHLEN);
     }
-//  strncpy(my_rig->state.pttport.pathname,(const char *)catParams.serialPort.toLatin1().data(),FILPATHLEN);
+//  strncpy(my_rig->state.pttport.pathname,(const char *)catParams.serialPort.toUtf8().data(),FILPATHLEN);
   my_rig->state.rigport.parm.serial.rate = catParams.baudrate;
   my_rig->state.rigport.parm.serial.data_bits=catParams.databits;
   my_rig->state.rigport.parm.serial.stop_bits=catParams.stopbits;
@@ -244,7 +244,7 @@ bool rigControl::setMode(QString mode,QString passBand)
       return true;
     }
 
-  rmode_t rmode=rig_parse_mode(mode.toLatin1().data());
+  rmode_t rmode=rig_parse_mode(mode.toUtf8().data());
   if(passBand=="Narrow")
     {
       pb=rig_passband_narrow(my_rig,rmode);
@@ -379,7 +379,7 @@ void rigControl::activatePTT(bool b)
       if (catParams.pttSerialPort.isEmpty()) return;
       if(serialP==0)
         {
-          serialP=::open(catParams.pttSerialPort.toLatin1().data(),O_RDWR);
+          serialP=::open(catParams.pttSerialPort.toUtf8().data(),O_RDWR);
           if (serialP<=0)
             {
               QMessageBox::warning(txWidgetPtr,"Serial Port Error",
@@ -471,7 +471,7 @@ int  rigControl::rawCommand(QByteArray ba)
         }
 
       command+="\n";
-      cmdBa=command.toLatin1();
+      cmdBa=command.toUtf8();
       result=write_block(&rs->rigport,cmdBa.constData(), cmdBa.count());
 
     }

--- a/qsstv/sound/soundalsa.cpp
+++ b/qsstv/sound/soundalsa.cpp
@@ -32,7 +32,7 @@ bool soundAlsa::init(int samplerate)
   tempDevice=outputAudioDevice.left(outputAudioDevice.indexOf(" "));
   for(iteration=0;iteration<20;iteration++)
     {
-      err = snd_pcm_open(&playbackHandle,tempDevice.toLatin1().data(), SND_PCM_STREAM_PLAYBACK,0); //open in blocking mode
+      err = snd_pcm_open(&playbackHandle,tempDevice.toUtf8().data(), SND_PCM_STREAM_PLAYBACK,0); //open in blocking mode
       if (err==-EBUSY)
         {
           msleep(500);
@@ -46,7 +46,7 @@ bool soundAlsa::init(int samplerate)
     }
   if(!alsaErrorHandler(err,"Unable to open "+outputAudioDevice)) return false;
   tempDevice=inputAudioDevice.left(inputAudioDevice.indexOf(" "));
-  err = snd_pcm_open(&captureHandle,tempDevice.toLatin1().data(), SND_PCM_STREAM_CAPTURE, 0);
+  err = snd_pcm_open(&captureHandle,tempDevice.toUtf8().data(), SND_PCM_STREAM_CAPTURE, 0);
   if(!alsaErrorHandler(err,"Unable to open "+inputAudioDevice)) return false;
   snd_pcm_hw_params_malloc ( &hwparams );
   snd_pcm_sw_params_malloc ( &swparams );

--- a/qsstv/sound/soundpulse.cpp
+++ b/qsstv/sound/soundpulse.cpp
@@ -73,8 +73,8 @@ bool soundPulse::init(int samplerate)
 
   // opening device
   sname=QString("capture %1").arg(getpid());
-  sd[0].stream = pa_simple_new(NULL, shortName.toLatin1().data(), sd[0].dir, NULL,sname.toLatin1().data(), &sd[0].stream_params, NULL,&sd[0].buffer_attrs, &err);
-//  sd[0].stream = pa_simple_new(NULL, shortName.toLatin1().data(), sd[0].dir, NULL,sname.toLatin1().data(), &sd[0].stream_params, NULL,&sd[0].buffer_attrs, &err);
+  sd[0].stream = pa_simple_new(NULL, shortName.toUtf8().data(), sd[0].dir, NULL,sname.toUtf8().data(), &sd[0].stream_params, NULL,&sd[0].buffer_attrs, &err);
+//  sd[0].stream = pa_simple_new(NULL, shortName.toUtf8().data(), sd[0].dir, NULL,sname.toUtf8().data(), &sd[0].stream_params, NULL,&sd[0].buffer_attrs, &err);
   if(sd[0].stream==NULL)
   {
     errorHandler("PulseAudio read init error",QString(pa_strerror(err)));
@@ -82,7 +82,7 @@ bool soundPulse::init(int samplerate)
   }
 
   sname=QString("playback %1").arg(getpid());
-  sd[1].stream = pa_simple_new(NULL, shortName.toLatin1().data(), sd[1].dir, NULL,sname.toLatin1().data(), &sd[1].stream_params, NULL,&sd[1].buffer_attrs, &err);
+  sd[1].stream = pa_simple_new(NULL, shortName.toUtf8().data(), sd[1].dir, NULL,sname.toUtf8().data(), &sd[1].stream_params, NULL,&sd[1].buffer_attrs, &err);
   if(sd[1].stream==NULL)
   {
     errorHandler("PulseAudio read init error",QString(pa_strerror(err)));

--- a/qsstv/utils/hexconvertor.cpp
+++ b/qsstv/utils/hexconvertor.cpp
@@ -21,7 +21,7 @@ bool hexFromString(QString s,QByteArray &ba,bool toHex)
     }
   else
     {
-      ba=s.toLatin1();
+      ba=s.toUtf8();
     }
   return true;
 }

--- a/qsstv/utils/jp2io.cpp
+++ b/qsstv/utils/jp2io.cpp
@@ -168,7 +168,7 @@ QImage jp2IO::decode(QString fileName)
   int wr, hr;         // taken from OpenJPEG
   init();
 
-  l_stream = opj_stream_create_default_file_stream(fileName.toLatin1(),1);
+  l_stream = opj_stream_create_default_file_stream(fileName.toUtf8(),1);
   if (!l_stream)
     {
       addToLogDebug( QString("ERROR -> failed to create the stream from the file %1").arg(parameters.infile),LOGALL);
@@ -409,7 +409,7 @@ QByteArray jp2IO::encode(QImage qimage, QImage &newImage,int &fileSize, int comp
 {
   QByteArray byteArray;
   QString fn=QString("%1/%2").arg(QDir::tempPath()).arg("qsstv.tmp");
-  //  char *of=fn.toLatin1().data();
+  //  char *of=fn.toUtf8().data();
   bool success;
   init();
   fileSize=0;
@@ -417,7 +417,7 @@ QByteArray jp2IO::encode(QImage qimage, QImage &newImage,int &fileSize, int comp
   cparameters.cp_disto_alloc = 1;
   createImage(qimage);
   cparameters.cod_format=JP2_CFMT;
-  if(opj_strcpy_s(cparameters.outfile, sizeof(cparameters.outfile), fn.toLatin1().data()) != 0)
+  if(opj_strcpy_s(cparameters.outfile, sizeof(cparameters.outfile), fn.toUtf8().data()) != 0)
     {
       return byteArray;
     }

--- a/qsstv/utils/qftp.cpp
+++ b/qsstv/utils/qftp.cpp
@@ -485,7 +485,7 @@ static void _q_parseUnixDir(const QStringList &tokens, const QString &userName, 
   if (tokens.size() != 8)
     return;
 
-  char first = tokens.at(1).at(0).toLatin1();
+  char first = tokens.at(1).at(0).toUtf8();
   if (first == 'd') {
       info->setDir(true);
       info->setFile(false);
@@ -619,7 +619,7 @@ bool QFtpDTP::parseDir(const QByteArray &buffer, const QString &userName, QUrlIn
   if (buffer.isEmpty())
     return false;
 
-  QString bufferStr = QString::fromLatin1(buffer).trimmed();
+  QString bufferStr = QString::fromUtf8(buffer).trimmed();
 
   // Unix style FTP servers
   QRegExp unixPattern(QLatin1String("^([\\-dl])([a-zA-Z\\-]{9,9})\\s+\\d+\\s+(\\S*)\\s+"
@@ -678,7 +678,7 @@ void QFtpDTP::socketReadyRead()
               // does not exist, but rather write a text to the data socket
               // -- try to catch these cases
               if (line.endsWith("No such file or directory\r\n"))
-                err = QString::fromLatin1(line);
+                err = QString::fromUtf8(line);
             }
         }
     } else {
@@ -912,7 +912,7 @@ void QFtpPI::readyRead()
 
   while (commandSocket.canReadLine()) {
       // read line with respect to line continuation
-      QString line = QString::fromLatin1(commandSocket.readLine());
+      QString line = QString::fromUtf8(commandSocket.readLine());
       if (replyText.isEmpty()) {
           if (line.length() < 3) {
               // protocol error
@@ -944,7 +944,7 @@ void QFtpPI::readyRead()
             replyText += line;
           if (!commandSocket.canReadLine())
             return;
-          line = QString::fromLatin1(commandSocket.readLine());
+          line = QString::fromUtf8(commandSocket.readLine());
           lineLeft4 = line.left(4);
         }
       replyText += line.mid(4); // strip reply code 'xyz '
@@ -967,7 +967,7 @@ bool QFtpPI::processReply()
   addToLog(QString("state: %1 [processReply() begin]").arg(state),LOGQFTP);
   if (replyText.length() < 400)
     {
-      addToLog(QString("recv: %1 %2").arg(100*replyCode[0]+10*replyCode[1]+replyCode[2]).arg(replyText.toLatin1().constData()),LOGQFTP);
+      addToLog(QString("recv: %1 %2").arg(100*replyCode[0]+10*replyCode[1]+replyCode[2]).arg(replyText.toUtf8().constData()),LOGQFTP);
     }
   else
     {
@@ -1181,9 +1181,9 @@ bool QFtpPI::startNextCmd()
     }
 
   pendingCommands.pop_front();
-  addToLog(QString("send: %1").arg(currentCmd.left(currentCmd.length()-2).toLatin1().constData()),LOGQFTP);
+  addToLog(QString("send: %1").arg(currentCmd.left(currentCmd.length()-2).toUtf8().constData()),LOGQFTP);
   state = WAITING;
-  commandSocket.write(currentCmd.toLatin1());
+  commandSocket.write(currentCmd.toUtf8());
   return true;
 }
 
@@ -2272,39 +2272,39 @@ void QFtpPrivate::_q_piError(int errorCode, const QString &text)
   switch (q->currentCommand())
     {
     case QFtp::ConnectToHost:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Connecting to host failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Connecting to host failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Login:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Login failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Login failed:\n%1"))
           .arg(text);
       break;
     case QFtp::List:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Listing directory failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Listing directory failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Cd:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Changing directory failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Changing directory failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Get:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Downloading file failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Downloading file failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Put:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Uploading file failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Uploading file failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Remove:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Removing file failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Removing file failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Mkdir:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Creating directory failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Creating directory failed:\n%1"))
           .arg(text);
       break;
     case QFtp::Rmdir:
-      errorString = QString::fromLatin1(QT_TRANSLATE_NOOP("QFtp", "Removing directory failed:\n%1"))
+      errorString = QString::fromUtf8(QT_TRANSLATE_NOOP("QFtp", "Removing directory failed:\n%1"))
           .arg(text);
       break;
     default:

--- a/qsstv/utils/reedsolomoncoder.cpp
+++ b/qsstv/utils/reedsolomoncoder.cpp
@@ -276,9 +276,9 @@ bool reedSolomonCoder::encode(QByteArray &ba,QString extension,eRSType rsType)
   ec_buf.append(dataByte);
   dataByte = (unsigned char) (chunks/256) ;
   ec_buf.append(dataByte);
-  ec_buf.append(suffix.toLatin1().at(0));
-  ec_buf.append(suffix.toLatin1().at(1));
-  ec_buf.append(suffix.toLatin1().at(2));
+  ec_buf.append(suffix.toUtf8().at(0));
+  ec_buf.append(suffix.toUtf8().at(1));
+  ec_buf.append(suffix.toUtf8().at(2));
   dataByte=0;
   ec_buf.append(dataByte);
   ec_buf.append(tr_buf.left(rs_dsize-7));

--- a/qsstv/utils/supportfunctions.cpp
+++ b/qsstv/utils/supportfunctions.cpp
@@ -333,7 +333,7 @@ bool trash(QString filename,bool forceDelete)
     if(forceDelete) orgFile.remove();
     return false;
   }
-  infoFile.write(infoTxt.toLatin1().data());
+  infoFile.write(infoTxt.toUtf8().data());
   infoFile.close();
   QFile trashFile(info.absoluteFilePath());
   QString target;

--- a/qsstv/videocapt/cameradialog.cpp
+++ b/qsstv/videocapt/cameradialog.cpp
@@ -203,7 +203,7 @@ void cameraDialog::getCameraInfo(QStringList devList)
       struct v4l2_capability cap;
       memset(&cap, 0, sizeof(cap));
       camDev=QString("/dev/")+devList.at(i);
-      fd = v4l2_open(camDev.toLatin1().data(), O_RDWR, 0);
+      fd = v4l2_open(camDev.toUtf8().data(), O_RDWR, 0);
       if(fd < 0)
         {
           QString msg=QString("Unable to open file %1\n%2").arg(camDev).arg(strerror(errno));

--- a/qsstv/videocapt/imagesettings.cpp
+++ b/qsstv/videocapt/imagesettings.cpp
@@ -77,7 +77,7 @@
 
 imageSettings::imageSettings(QString cameraDevice, QWidget *parent) :   QDialog(parent)
 {
-  camDev=cameraDevice.toLatin1();
+  camDev=cameraDevice.toUtf8();
   ui= new Ui::imageSettingsUi;
   ui->setupUi(this);
   gridLayout=NULL;

--- a/qsstv/videocapt/videocapture.cpp
+++ b/qsstv/videocapt/videocapture.cpp
@@ -86,7 +86,7 @@ bool videoCapture::open(QString videoDev)
   if (opened) return true;
   addToLog("opening Videocapture device",LOGCAM);
 
-  dev = v4l2_open(videoDevice.toLatin1().data(), O_RDWR);
+  dev = v4l2_open(videoDevice.toUtf8().data(), O_RDWR);
   if (dev < 0)
     {
       addToLog(QString("Error opening %1, %2").arg(videoDevice).arg(errno),LOGCAM);

--- a/qsstv/widgets/imageviewer.cpp
+++ b/qsstv/widgets/imageviewer.cpp
@@ -804,7 +804,7 @@ void imageViewer::save(QString fileName,QString fmt,bool convertRGB, bool source
       if(source) im=sourceImage.convertToFormat(QImage::Format_RGB32);
       else im=displayedImage.convertToFormat(QImage::Format_RGB32);
     }
-  im.save(fileName,fmt.toUpper().toLatin1().data());
+  im.save(fileName,fmt.toUpper().toUtf8().data());
 }
 
 bool imageViewer::copyToBuffer(QByteArray *ba)

--- a/qsstv/xmlrpc/ipcmessage.cpp
+++ b/qsstv/xmlrpc/ipcmessage.cpp
@@ -35,7 +35,7 @@ bool ipcMessage::sendMessage(QString t)
   int len;
   // message to send
   msgBuf.mtype = MTYPE; // set the type of message
-  strncpy(msgBuf.mtext,t.toLatin1().data(),MSGTXMAXLEN);
+  strncpy(msgBuf.mtext,t.toUtf8().data(),MSGTXMAXLEN);
   len=strlen(msgBuf.mtext);
 
   // send the message to queue

--- a/qsstv/xmlrpc/maiaObject.cpp
+++ b/qsstv/xmlrpc/maiaObject.cpp
@@ -211,7 +211,7 @@ QVariant MaiaObject::fromXml(const QDomElement &elem)
         if(typeElement.text().toLower() == "true" || typeElement.text() == "1") return QVariant(true);
         else  return QVariant(false);
     }
-    else if(typeName == "base64") return QVariant(QByteArray::fromBase64( typeElement.text().toLatin1()));
+    else if(typeName == "base64") return QVariant(QByteArray::fromBase64( typeElement.text().toUtf8()));
     else if(typeName == "datetime" || typeName == "datetime.iso8601") return QVariant(QDateTime::fromString(typeElement.text(), "yyyyMMddThh:mm:ss"));
     else if(typeName == "nil")  return QVariant(); // Non-standard extension: http://ontosys.com/xml-rpc/extensions.php
     else if ( typeName == "array" )

--- a/qsstv/xmlrpc/maiaXmlRpcClient.cpp
+++ b/qsstv/xmlrpc/maiaXmlRpcClient.cpp
@@ -44,7 +44,7 @@ MaiaXmlRpcClient::MaiaXmlRpcClient(QUrl url, QObject* parent) : QObject(parent),
 MaiaXmlRpcClient::MaiaXmlRpcClient(QUrl url, QString userAgent, QObject *parent) : QObject(parent) {
 	// userAgent should adhere to RFC 1945 http://tools.ietf.org/html/rfc1945
 	init();
-	request.setRawHeader("User-Agent", userAgent.toLatin1());
+	request.setRawHeader("User-Agent", userAgent.toUtf8());
 	setUrl(url);
 }
 
@@ -68,7 +68,7 @@ void MaiaXmlRpcClient::setUrl(QUrl url)
 }
 
 void MaiaXmlRpcClient::setUserAgent(QString userAgent) {
-	request.setRawHeader("User-Agent", userAgent.toLatin1());
+	request.setRawHeader("User-Agent", userAgent.toUtf8());
 }
 
 QNetworkReply* MaiaXmlRpcClient::call(QString method, QList<QVariant> args,

--- a/qwt/qwt_plot_renderer.cpp
+++ b/qwt/qwt_plot_renderer.cpp
@@ -264,7 +264,7 @@ void QwtPlotRenderer::renderDocument( QwtPlot *plot,
     else
     {
         if ( QImageWriter::supportedImageFormats().indexOf(
-            format.toLatin1() ) >= 0 )
+            format.toUtf8() ) >= 0 )
         {
             const QRect imageRect = documentRect.toRect();
             const int dotsPerMeter = qRound( resolution * mmToInch * 1000.0 );
@@ -278,7 +278,7 @@ void QwtPlotRenderer::renderDocument( QwtPlot *plot,
             render( plot, &painter, imageRect );
             painter.end();
 
-            image.save( fileName, format.toLatin1() );
+            image.save( fileName, format.toUtf8() );
         }
     }
 }

--- a/qwt/qwt_text_engine.cpp
+++ b/qwt/qwt_text_engine.cpp
@@ -26,18 +26,18 @@ static QString taggedRichText( const QString &text, int flags )
     // By default QSimpleRichText is Qt::AlignLeft
     if ( flags & Qt::AlignJustify )
     {
-        richText.prepend( QString::fromLatin1( "<div align=\"justify\">" ) );
-        richText.append( QString::fromLatin1( "</div>" ) );
+        richText.prepend( QString::fromUtf8( "<div align=\"justify\">" ) );
+        richText.append( QString::fromUtf8( "</div>" ) );
     }
     else if ( flags & Qt::AlignRight )
     {
-        richText.prepend( QString::fromLatin1( "<div align=\"right\">" ) );
-        richText.append( QString::fromLatin1( "</div>" ) );
+        richText.prepend( QString::fromUtf8( "<div align=\"right\">" ) );
+        richText.append( QString::fromUtf8( "</div>" ) );
     }
     else if ( flags & Qt::AlignHCenter )
     {
-        richText.prepend( QString::fromLatin1( "<div align=\"center\">" ) );
-        richText.append( QString::fromLatin1( "</div>" ) );
+        richText.prepend( QString::fromUtf8( "<div align=\"center\">" ) );
+        richText.append( QString::fromUtf8( "</div>" ) );
     }
 
     return richText;


### PR DESCRIPTION
I tried to receive some DRM hybrid images over the air, but I noticed that file names with non-ascii characters did not download at all. The files were all 0 bytes.

This is an example file name that was sent.

de_F5UGS-20-Capture d’écran (4285).jpg

It looks ok but that is no ordinary ' it is Unicode Character 'RIGHT SINGLE QUOTATION MARK' (U+2019)

You can see the files here: [ftp://uploads.easypal.org/HybridFiles1/](ftp://uploads.easypal.org/HybridFiles1/) and Firefox at least displays the character correctly.

So the first problem is that qsstv uses fromLatin1 and toLatin1 all over the code. This PR starts using UTF-8 for all string handling. But it doesn't solve the problem completely. At least now the filename that is produced is what is given by the easypal FTP server. But of course that FTP server doesn't have UTF-8 turned on:

```$ ftp uploads.easypal.org
Connected to uploads.easypal.org (198.46.156.18).
220 (vsFTPd 3.0.3)
Name (uploads.easypal.org:cjk): easypal
331 Please specify the password.
Password:
230 Login successful.
Remote system type is UNIX.
Using binary mode to transfer files.
ftp> quote feat
211-Features:
 EPRT
 EPSV
 MDTM
 PASV
 REST STREAM
 SIZE
 TVFS
211 End
ftp> cd HybridFiles1
250 Directory successfully changed.
ftp> ls
227 Entering Passive Mode (198,46,156,18,149,96).
150 Here comes the directory listing.
-rw-r--r--    1 ftp      ftp            16 Oct 23 07:42 A.txt
-rw-r--r--    1 ftp      ftp          9544 Nov 01 18:53 W5-10-Elpidio-Valdes-cola-coronavirus.jp2
-rw-r--r--    1 ftp      ftp         11987 Nov 12 20:06 W5-11-OX9A-3Gb_400x400.jp2
-rw-r--r--    1 ftp      ftp         14881 Nov 09 19:17 W5-14-elpidio-vald�s_poster-750x490.jp2
...
-rw-r--r--    1 ftp      ftp        138538 Nov 20 07:03 de_F5UGS-20-Capture d��cran (4285).jpg
-rw-r--r--    1 ftp      ftp        241617 Nov 20 07:05 de_F5UGS-21-Capture d��cran (4284).jpg
-rw-r--r--    1 ftp      ftp        135795 Nov 20 07:06 de_F5UGS-22-Capture d��cran (4283).jpg
-rw-r--r--    1 ftp      ftp        173526 Nov 20 07:09 de_F5UGS-23-Capture d��cran (4282).jpg
-rw-r--r--    1 ftp      ftp        184300 Nov 20 07:10 de_F5UGS-25-Capture d��cran (4281).jpg
-rw-r--r--    1 ftp      ftp        182253 Nov 20 07:14 de_F5UGS-26-Capture d��cran (4280).jpg
-rw-r--r--    1 ftp      ftp        221270 Nov 20 07:14 de_F5UGS-27-Capture d��cran (4279).jpg
...
```
I haven't looked at the hybrid ftp fetching code yet, but I thing using a url and URI coding the UTF-8 would work since at least firefox does the right thing.

So after applying this fix at least the file name is the same as on the ftp-server since it uses latin-1.

And we should probably talk to easypal.org and get them to turn on UTF-8 on their server. But this is a start at least.

Comments?

